### PR TITLE
Npm registry provider

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,3 +1,17 @@
+# Copyright © 2020 Atomist, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 schema: graphql/schema.json
 documents: graphql/**/*.graphql
 generates:

--- a/lib/definition/resource_provider/definition.ts
+++ b/lib/definition/resource_provider/definition.ts
@@ -136,6 +136,7 @@ export function mavenRepository(
 
 /**
  * Create an NpmJSRegistryProvider to use in Skill resourceProvider definitions
+ * @deprecated use npmRegistry
  */
 export function npmJSRegistry(
 	options: Omit<ResourceProvider, "typeName"> = {},
@@ -143,6 +144,19 @@ export function npmJSRegistry(
 	return resourceProvider({
 		displayName: "npmjs.com Registry",
 		typeName: "NpmJSRegistryProvider",
+		...options,
+	});
+}
+
+/**
+ * Create an NpmRegistryProvider to use in Skill resourceProvider definitions
+ */
+export function npmRegistry(
+	options: Omit<ResourceProvider, "typeName"> = {},
+): ResourceProvider {
+	return resourceProvider({
+		displayName: "NPM Registry",
+		typeName: "NpmRegistryProvider",
 		...options,
 	});
 }

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2020 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as assert from "assert";
 import { findGraphQLFile } from "../lib/graphql";
 


### PR DESCRIPTION
I'm not sure if we should do anything else, e.g., create `.npmrc` creator helper like https://github.com/atomist-skills/npm-release-skill/blob/main/lib/npm.ts .