### PR TITLE
Add version to package, quiet tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9035,5 +9035,6 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
-  }
+  },
+  "version": "0.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "scripts": {
     "autotest": "supervisor --watch index.ts,lib,test --extensions ts --no-restart-on exit --quiet --exec npm -- test",
-    "build": "run-s compile test lint doc",
+    "build": "run-s clean compile test lint doc",
     "clean": "run-p clean:compile clean:test clean:doc clean:run",
     "clean:compile": "rimraf git-info.json build \"index.{d.ts,js}{,.map}\" \"{bin,lib,test}/**/*.{d.ts,js}{,.map}\" lib/typings/types.ts",
     "clean:dist": "run-s clean clean:npm",
@@ -141,5 +141,6 @@
   "lint-staged": {
     "**/*.@(graphql|json|markdown|yaml|yml|md)": "npm run atm:lint:prettier",
     "**/*.ts": "npm run atm:lint:eslint"
-  }
+  },
+  "version": "0.2.0"
 }

--- a/test/github/tag.test.ts
+++ b/test/github/tag.test.ts
@@ -14,37 +14,53 @@
  * limitations under the License.
  */
 
-import * as assert from "assert";
+import * as assert from "power-assert";
 import { incrementTag } from "../../lib/github/tag";
+import * as log from "../../lib/log/console";
 
 describe("tags", () => {
 	describe("incrementTag", () => {
-		it("increment patch level tag", () => {
+		let origDebug: any;
+		before(() => {
+			origDebug = Object.getOwnPropertyDescriptor(log, "debug");
+			Object.defineProperty(log, "debug", {
+				value: () => {
+					return;
+				},
+			});
+		});
+		after(() => {
+			if (origDebug) {
+				Object.defineProperty(log, "debug", origDebug);
+			}
+		});
+
+		it("increments prerelease tag by prerelease", () => {
 			const tag = incrementTag(["0.1.0-1"], "prerelease");
 			assert.deepStrictEqual(tag, "0.1.0-2");
 		});
 
-		it("increment patch level tag by prerelease", () => {
+		it("increments patch tag by prerelease", () => {
 			const tag = incrementTag(["0.1.0"], "prerelease");
 			assert.deepStrictEqual(tag, "0.1.1-0");
 		});
 
-		it("increment from no tags", () => {
+		it("returns default prerelease", () => {
 			const tag = incrementTag([], "prerelease");
 			assert.deepStrictEqual(tag, "0.1.0-0");
 		});
 
-		it("increment patch level tag", () => {
+		it("increments patch tag by patch", () => {
 			const tag = incrementTag(["0.1.0-1", "0.1.1"], "patch");
 			assert.deepStrictEqual(tag, "0.1.2");
 		});
 
-		it("increment minor level tag", () => {
+		it("increment prelease tag by minor", () => {
 			const tag = incrementTag(["0.1.0-1"], "minor");
 			assert.deepStrictEqual(tag, "0.1.0");
 		});
 
-		it("increment major level tag", () => {
+		it("increment prerelease by major", () => {
 			const tag = incrementTag(["0.1.0-1"], "major");
 			assert.deepStrictEqual(tag, "1.0.0");
 		});


### PR DESCRIPTION
Not having the version in the package makes managing releases without
double tags on the same release impossible.  Changes to
npm-build-skill to deal with this situation are coming.

Quiet debug statements from tests.