### PR TITLE
Sort imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     "project": "tsconfig.json",
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "simple-import-sort"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-floating-promises": ["error"],
@@ -32,6 +32,10 @@
         "trailingComma": "all",
         "useTabs": true
       }
-    ]
+    ],
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+    "sort-imports": "off",
+    "import/order": "off"
   }
 }

--- a/bin/start.ts
+++ b/bin/start.ts
@@ -19,6 +19,7 @@
 import "source-map-support/register";
 
 import * as yargs from "yargs";
+
 import { error } from "../lib/log";
 
 // tslint:disable-next-line:no-unused-expression

--- a/index.ts
+++ b/index.ts
@@ -15,12 +15,9 @@
  */
 
 // lib/definition
+export * as parameter from "./lib/definition/parameter";
+export * as resourceProvider from "./lib/definition/resource_provider";
 export {
-	ParameterType,
-	ResourceProvider,
-	RepoFilterParameter,
-	Skill,
-	SkillInput,
 	BooleanParameter,
 	Category,
 	ChatChannelParameterValue,
@@ -30,17 +27,20 @@ export {
 	IntParameter,
 	LineStyle,
 	MultiChoiceParameter,
+	ParameterType,
 	ParameterVisibility,
 	Platform,
+	RepoFilterParameter,
+	ResourceProvider,
 	ScheduleParameter,
 	SingleChoiceParameter,
+	Skill,
+	skill,
+	SkillInput,
 	StringArrayParameter,
 	StringParameter,
 	Technology,
-	skill,
 } from "./lib/definition/skill";
-export * as parameter from "./lib/definition/parameter";
-export * as resourceProvider from "./lib/definition/resource_provider";
 export * as subscription from "./lib/definition/subscription";
 // lib/git
 export * as git from "./lib/git";
@@ -70,27 +70,27 @@ export * as childProcess from "./lib/child_process";
 export {} from "./lib/context";
 export { entryPoint } from "./lib/entry_point";
 export {} from "./lib/function";
-export { GraphQLClient, QueryOrLocation, Location } from "./lib/graphql";
+export { GraphQLClient, Location, QueryOrLocation } from "./lib/graphql";
 export {
-	Contextual,
 	CommandContext,
 	CommandHandler,
 	Configuration,
+	Contextual,
 	EventContext,
 	EventHandler,
 	HandlerStatus,
-	WebhookHandler,
 	WebhookContext,
+	WebhookHandler,
 } from "./lib/handler";
 export { HttpClient } from "./lib/http";
 export {
-	CommandMessageClient,
-	MessageClient,
-	RequiredMessageOptions,
-	MessageOptions,
-	Destinations,
-	SlackFileMessage,
 	AttachmentTarget,
+	CommandMessageClient,
+	Destinations,
+	MessageClient,
+	MessageOptions,
+	RequiredMessageOptions,
+	SlackFileMessage,
 } from "./lib/message";
 export {} from "./lib/payload";
 export * as state from "./lib/state";
@@ -101,6 +101,6 @@ export {
 	handleError,
 	handleErrorSync,
 	hideString,
-	toArray,
 	replacer,
+	toArray,
 } from "./lib/util";

--- a/lib/action.ts
+++ b/lib/action.ts
@@ -53,7 +53,7 @@ const onAttachmentAction: EventHandler<
 	} = JSON.parse(task.data);
 
 	if (data.configuration !== ctx.configuration.name) {
-		return success(`Not running command this configuration`).hidden();
+		return success(`Not running command for configuration`).hidden();
 	}
 
 	const payload = data.payload;

--- a/lib/child_process.ts
+++ b/lib/child_process.ts
@@ -20,6 +20,7 @@ import {
 	SpawnSyncReturns,
 } from "child_process";
 import * as process from "process";
+
 import { debug, error, warn } from "./log";
 
 /**

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -17,10 +17,10 @@
 import { createGraphQLClient } from "./graphql";
 import {
 	CommandContext,
+	Configuration,
 	ContextualLifecycle,
 	EventContext,
 	WebhookContext,
-	Configuration,
 } from "./handler";
 import { createHttpClient } from "./http";
 import { wrapAuditLogger } from "./log/util";

--- a/lib/definition/parameter/index.ts
+++ b/lib/definition/parameter/index.ts
@@ -15,8 +15,8 @@
  */
 
 export {
-	repoFilter,
-	refFilter,
 	PushStrategy,
 	pushStrategy,
+	refFilter,
+	repoFilter,
 } from "./definition";

--- a/lib/definition/subscription/named.ts
+++ b/lib/definition/subscription/named.ts
@@ -16,6 +16,7 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
+
 import { inlineFragments } from "./util";
 
 export function named(name: string): string {

--- a/lib/definition/subscription/util.ts
+++ b/lib/definition/subscription/util.ts
@@ -15,9 +15,9 @@
  */
 
 import * as fs from "fs-extra";
+import gql from "graphql-tag";
 import * as path from "path";
 import * as p from "path";
-import gql from "graphql-tag";
 
 const FragmentExpression = /\.\.\.\s*([_A-Za-z][_0-9A-Za-z]*)/gi;
 

--- a/lib/function.ts
+++ b/lib/function.ts
@@ -18,6 +18,7 @@
 import "source-map-support/register";
 
 import { Severity } from "@atomist/skill-logging";
+
 import { eventHandlerLoader } from "./action";
 import { ContextFactory, createContext } from "./context";
 import {

--- a/lib/git/index.ts
+++ b/lib/git/index.ts
@@ -15,15 +15,15 @@
  */
 
 export {
-	commit,
-	status,
-	push,
-	createBranch,
-	checkout,
 	changedFiles,
-	init,
-	revert,
-	hasBranch,
-	setUserConfig,
+	checkout,
+	commit,
+	createBranch,
 	GitPushOptions,
+	hasBranch,
+	init,
+	push,
+	revert,
+	setUserConfig,
+	status,
 } from "./operation";

--- a/lib/git/operation.ts
+++ b/lib/git/operation.ts
@@ -15,11 +15,12 @@
  */
 
 import * as pRetry from "p-retry";
+
 import { execPromise, spawnPromise } from "../child_process";
 import { debug } from "../log/index";
 import { Project } from "../project/project";
 import { cwd } from "../project/util";
-import { Status, runStatusIn } from "./status";
+import { runStatusIn, Status } from "./status";
 import forOwn = require("lodash.forown");
 
 /** Default name of default git remote. */

--- a/lib/github/check.ts
+++ b/lib/github/check.ts
@@ -16,9 +16,10 @@
 
 import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods/dist-types/generated/parameters-and-response-types";
 import {
-	ChecksUpdateResponseData,
 	ChecksCreateResponseData,
+	ChecksUpdateResponseData,
 } from "@octokit/types";
+
 import { Contextual } from "../handler";
 import { AuthenticatedRepositoryId } from "../repository/id";
 import { GitHubAppCredential, GitHubCredential } from "../secret/provider";

--- a/lib/github/index.ts
+++ b/lib/github/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { UpdateCheck, CreateCheck, Check, createCheck } from "./check";
-export { api, formatMarkers, formatFooter, convergeLabel } from "./operation";
-export { persistChanges, closePullRequests } from "./pull_request";
+export { Check, CreateCheck, createCheck, UpdateCheck } from "./check";
+export { api, convergeLabel, formatFooter, formatMarkers } from "./operation";
+export { closePullRequests, persistChanges } from "./pull_request";
 export { nextTag } from "./tag";

--- a/lib/github/operation.ts
+++ b/lib/github/operation.ts
@@ -15,6 +15,7 @@
  */
 
 import { Octokit } from "@octokit/rest"; // eslint-disable-line @typescript-eslint/no-unused-vars
+
 import { Contextual } from "../handler";
 import { AuthenticatedRepositoryId } from "../repository/id";
 import { GitHubAppCredential, GitHubCredential } from "../secret/provider";

--- a/lib/github/pull_request.ts
+++ b/lib/github/pull_request.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from "fs-extra";
+
 import { PushStrategy } from "../definition/parameter/definition";
 import * as git from "../git/operation";
 import { Contextual, HandlerStatus } from "../handler";

--- a/lib/github/tag.ts
+++ b/lib/github/tag.ts
@@ -15,6 +15,7 @@
  */
 
 import * as semver from "semver";
+
 import { debug } from "../log/console";
 import { AuthenticatedRepositoryId } from "../repository/id";
 import { GitHubAppCredential, GitHubCredential } from "../secret/provider";

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -19,6 +19,7 @@ import * as fs from "fs-extra";
 import { Response } from "node-fetch";
 import * as pRetry from "p-retry";
 import * as path from "path";
+
 import { inlineFragments } from "./definition/subscription/util";
 import { debug, warn } from "./log/console";
 import { retry } from "./retry";

--- a/lib/handler.ts
+++ b/lib/handler.ts
@@ -15,6 +15,7 @@
  */
 
 import { Logger } from "@atomist/skill-logging/lib/logging";
+
 import { GraphQLClient } from "./graphql";
 import { HttpClient } from "./http";
 import { CommandMessageClient, MessageClient } from "./message";

--- a/lib/log/index.ts
+++ b/lib/log/index.ts
@@ -15,5 +15,5 @@
  */
 
 export { debug, error, info, warn } from "./console";
-export { redact, DEFAULT_REDACTION_PATTERNS } from "./redact";
+export { DEFAULT_REDACTION_PATTERNS, redact } from "./redact";
 export { Severity } from "@atomist/skill-logging";

--- a/lib/log/util.ts
+++ b/lib/log/util.ts
@@ -15,6 +15,7 @@
  */
 
 import { createLogger, Logger, Severity } from "@atomist/skill-logging";
+
 import { toArray } from "../util";
 import { error, info, warn } from "./console";
 

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -15,14 +15,15 @@
  */
 
 import {
+	Action as SlackAction,
 	ActionsBlock,
 	Attachment,
 	render,
 	SectionBlock,
 	SlackMessage,
 } from "@atomist/slack-messages";
-import { Action as SlackAction } from "@atomist/slack-messages/lib/SlackMessages";
 import { PubSub } from "@google-cloud/pubsub";
+
 import { GraphQLClient } from "./graphql";
 import {
 	CommandContext,

--- a/lib/project/clone.ts
+++ b/lib/project/clone.ts
@@ -17,6 +17,7 @@
 import * as os from "os";
 import * as pRetry from "p-retry";
 import * as path from "path";
+
 import { execPromise } from "../child_process";
 import { debug } from "../log";
 import { AuthenticatedRepositoryId } from "../repository/id";

--- a/lib/project/index.ts
+++ b/lib/project/index.ts
@@ -15,5 +15,5 @@
  */
 
 export { ProjectLoader } from "./loader";
-export { withGlobMatches, cwd, globFiles } from "./util";
-export { Project, Spawn, Exec } from "./project";
+export { Exec, Project, Spawn } from "./project";
+export { cwd, globFiles, withGlobMatches } from "./util";

--- a/lib/project/loader.ts
+++ b/lib/project/loader.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from "fs-extra";
+
 import { Contextual } from "../handler";
 import { AuthenticatedRepositoryId } from "../repository/id";
 import { CloneOptions } from "./clone";

--- a/lib/project/project.ts
+++ b/lib/project/project.ts
@@ -16,6 +16,7 @@
 
 import { SpawnSyncOptions } from "child_process";
 import * as path from "path";
+
 import {
 	execPromise,
 	ExecPromiseResult,
@@ -23,11 +24,11 @@ import {
 	SpawnPromiseOptions,
 	SpawnPromiseReturns,
 } from "../child_process";
+import { setUserConfig } from "../git";
 import { debug } from "../log";
 import { AuthenticatedRepositoryId } from "../repository/id";
 import { handleError } from "../util";
 import { CloneOptions, doClone } from "./clone";
-import { setUserConfig } from "../git";
 
 export type Spawn = (
 	cmd: string,

--- a/lib/project/util.ts
+++ b/lib/project/util.ts
@@ -15,6 +15,7 @@
  */
 
 import { Options } from "fast-glob";
+
 import { Project } from "./project";
 
 /**

--- a/lib/prompt/index.ts
+++ b/lib/prompt/index.ts
@@ -15,16 +15,16 @@
  */
 
 export {
-	ParameterPrompt,
-	ParameterPromptStyle,
-	ParameterPromptOptions,
-	ParameterPromptObject,
-} from "./prompt";
-export {
-	ParameterObjectValue,
-	Options,
-	Option,
 	BaseParameter,
 	HasDefaultValue,
+	Option,
+	Options,
+	ParameterObjectValue,
 } from "./parameter";
+export {
+	ParameterPrompt,
+	ParameterPromptObject,
+	ParameterPromptOptions,
+	ParameterPromptStyle,
+} from "./prompt";
 export { configurationWithParameters } from "./util";

--- a/lib/prompt/prompt.ts
+++ b/lib/prompt/prompt.ts
@@ -15,8 +15,8 @@
  */
 
 import { CommandMessageClient, HandlerResponse, Parameter } from "../message";
-import { ParameterObjectValue } from "./parameter";
 import { Arg, CommandIncoming } from "../payload";
+import { ParameterObjectValue } from "./parameter";
 import cloneDeep = require("lodash.clonedeep");
 import map = require("lodash.map");
 import set = require("lodash.set");

--- a/lib/repository/index.ts
+++ b/lib/repository/index.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+export { matchesFilter, matchesRefFilter, matchesRepoFilter } from "./filter";
 export {
-	RepositoryId,
 	AuthenticatedRepositoryId,
-	RepositoryProviderType,
 	gitHubComRepository as gitHub,
+	RepositoryId,
+	RepositoryProviderType,
 } from "./id";
 export { linkedRepositories, linkedRepository } from "./linked";
-export { matchesFilter, matchesRefFilter, matchesRepoFilter } from "./filter";

--- a/lib/script/gql_fetch.ts
+++ b/lib/script/gql_fetch.ts
@@ -16,6 +16,7 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
+
 import { createGraphQLClient } from "../graphql";
 import { info } from "../log";
 import { apiKey, wid } from "./skill_register";

--- a/lib/script/gql_generate.ts
+++ b/lib/script/gql_generate.ts
@@ -16,9 +16,10 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
+
 import { spawnPromise } from "../child_process";
-import { globFiles } from "../project/util";
 import { info } from "../log";
+import { globFiles } from "../project/util";
 
 export async function generateGql(options: {
 	cwd: string;

--- a/lib/script/skill_bundle.ts
+++ b/lib/script/skill_bundle.ts
@@ -16,6 +16,7 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
+
 import { spawnPromise } from "../child_process";
 import { debug, info } from "../log";
 import { withGlobMatches } from "../project/util";

--- a/lib/script/skill_clean.ts
+++ b/lib/script/skill_clean.ts
@@ -16,6 +16,7 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
+
 import { info } from "../log";
 
 /**

--- a/lib/script/skill_container.ts
+++ b/lib/script/skill_container.ts
@@ -18,9 +18,10 @@ import { toEDNStringFromSimpleObject } from "edn-data";
 import * as fs from "fs-extra";
 import * as yaml from "js-yaml";
 import * as path from "path";
+
 import { spawnPromise } from "../child_process";
-import { info } from "../log";
 import { packageJson } from "../definition/skill";
+import { info } from "../log";
 import { globFiles, withGlobMatches } from "../project/util";
 import { AtomistSkillInput, AtomistSkillRuntime, content } from "./skill_input";
 import merge = require("lodash.merge");

--- a/lib/script/skill_input.ts
+++ b/lib/script/skill_input.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import { toEDNStringFromSimpleObject } from "edn-data";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { toEDNStringFromSimpleObject } from "edn-data";
+
+import { Skill } from "../definition/skill";
 import { named } from "../definition/subscription/named";
 import { error, info } from "../log";
 import { withGlobMatches } from "../project/util";
-import { Skill } from "../definition/skill";
 import { handleError, handlerLoader } from "../util";
 import { createYamlSkillInput, defaults } from "./skill_container";
 import map = require("lodash.map");

--- a/lib/script/skill_package.ts
+++ b/lib/script/skill_package.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import * as path from "path";
 import * as fs from "fs-extra";
+import * as path from "path";
+
 import { info } from "../log";
 
 export async function packageSkill(

--- a/lib/script/skill_register.ts
+++ b/lib/script/skill_register.ts
@@ -19,10 +19,11 @@ import * as yaml from "js-yaml";
 import * as os from "os";
 import * as path from "path";
 import * as semver from "semver";
+
 import { spawnPromise } from "../child_process";
+import * as git from "../git";
 import { createGraphQLClient, GraphQLClient } from "../graphql";
 import { error, info } from "../log";
-import * as git from "../git";
 import { GoogleCloudStorageProvider } from "../storage/provider";
 import { AtomistSkillInput } from "./skill_input";
 

--- a/lib/script/skill_run.ts
+++ b/lib/script/skill_run.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from "fs-extra";
+
 import { processCommand, processEvent, processWebhook } from "../function";
 import {
 	isCommandIncoming,

--- a/lib/secret/index.ts
+++ b/lib/secret/index.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-export {
-	CredentialResolver,
-	CredentialProvider,
-	GitHubCredential,
-	GitHubAppCredential,
-} from "./provider";
-export { gitHubUserToken, gitHubAppToken } from "./resolver";
 export { GenericSecret, genericSecret } from "./generic_resolver";
+export {
+	CredentialProvider,
+	CredentialResolver,
+	GitHubAppCredential,
+	GitHubCredential,
+} from "./provider";
+export { gitHubAppToken, gitHubUserToken } from "./resolver";

--- a/lib/slack/block.ts
+++ b/lib/slack/block.ts
@@ -15,6 +15,7 @@
  */
 
 import { ButtonElement, Element, SlackModal } from "@atomist/slack-messages";
+
 import { ParameterType } from "./button";
 
 export function buttonForModal(

--- a/lib/slack/button.ts
+++ b/lib/slack/button.ts
@@ -16,6 +16,7 @@
 
 import { Action } from "@atomist/slack-messages";
 import { flatten } from "flat";
+
 import { CommandReferencingAction } from "../message";
 import merge = require("lodash.merge");
 import forOwn = require("lodash.forown");

--- a/lib/slack/index.ts
+++ b/lib/slack/index.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-export * from "./messages";
+export * as block from "./block";
 export {
-	menuForCommand,
-	buttonForCommand,
-	ParameterType,
 	ActionConfirmation,
+	buttonForCommand,
 	ButtonSpecification,
 	DataSource,
+	menuForCommand,
 	MenuSpecification,
 	OptionGroup,
 	ParameterIndexType,
+	ParameterType,
 	SelectOption,
 } from "./button";
-export * as block from "./block";
+export * from "./messages";
 export * from "@atomist/slack-messages";

--- a/lib/slack/messages.ts
+++ b/lib/slack/messages.ts
@@ -15,6 +15,7 @@
  */
 
 import { Attachment, SlackMessage, url } from "@atomist/slack-messages";
+
 import { Contextual } from "../handler";
 import { guid } from "../util";
 

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -17,6 +17,7 @@
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
+
 import { Contextual } from "./handler";
 import { warn } from "./log/console";
 import { guid } from "./util";

--- a/lib/steps.ts
+++ b/lib/steps.ts
@@ -15,6 +15,7 @@
  */
 
 import { Severity } from "@atomist/skill-logging";
+
 import { CommandContext, EventContext, HandlerStatus } from "./handler";
 import { warn } from "./log";
 import { toArray } from "./util";

--- a/lib/storage/cache.ts
+++ b/lib/storage/cache.ts
@@ -18,6 +18,7 @@ import * as fs from "fs-extra";
 import * as JSZip from "jszip";
 import * as os from "os";
 import * as path from "path";
+
 import { CommandContext, EventContext } from "../handler";
 import { debug, warn } from "../log/console";
 import { Project } from "../project/project";

--- a/lib/storage/provider.ts
+++ b/lib/storage/provider.ts
@@ -17,6 +17,7 @@
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
+
 import { guid } from "../util";
 
 export interface StorageProvider {

--- a/lib/transact/transact.ts
+++ b/lib/transact/transact.ts
@@ -16,6 +16,7 @@
 
 import { PubSub } from "@google-cloud/pubsub";
 import { toEDNStringFromSimpleObject } from "edn-data";
+
 import { debug, error } from "../log/console";
 import { replacer, toArray } from "../util";
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import * as crypto from "crypto";
 import * as fs from "fs-extra";
 import * as path from "path";
 import { v4 as uuidv4 } from "uuid";
+
 import { error } from "./log";
 import { Arg } from "./payload";
-import * as crypto from "crypto";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function hash(obj: any): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4008,6 +4008,12 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "eslint": "^7.15.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "espower-typescript": "^9.0.2",
     "husky": "^4.3.5",
     "lint-staged": "^10.5.3",

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "power-assert";
+
 import { createContext } from "../lib/context";
 import { guid } from "../lib/util";
 

--- a/test/definition/subscription/named.test.ts
+++ b/test/definition/subscription/named.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "assert";
+
 import { named } from "../../../lib/definition/subscription/named";
 
 describe("named", () => {

--- a/test/definition/subscription/util.test.ts
+++ b/test/definition/subscription/util.test.ts
@@ -16,6 +16,7 @@
 
 import * as assert from "assert";
 import * as path from "path";
+
 import { inlineFragments } from "../../../lib/definition/subscription/util";
 
 describe("util", () => {

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "power-assert";
+
 import { processEvent, processWebhook } from "../lib/function";
 import { success } from "../lib/status";
 import { guid } from "../lib/util";

--- a/test/github/check.test.ts
+++ b/test/github/check.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "power-assert";
+
 import { truncateText } from "../../lib/github/check";
 
 describe("check", () => {

--- a/test/github/tag.test.ts
+++ b/test/github/tag.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "power-assert";
+
 import { incrementTag } from "../../lib/github/tag";
 import * as log from "../../lib/log/console";
 

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "assert";
+
 import { findGraphQLFile } from "../lib/graphql";
 
 describe("graphql", () => {

--- a/test/project/loader.ts
+++ b/test/project/loader.ts
@@ -16,6 +16,7 @@
 
 import * as assert from "assert";
 import * as fs from "fs-extra";
+
 import { createProjectLoader } from "../../lib/project/loader";
 import { gitHubComRepository } from "../../lib/repository/id";
 

--- a/test/project/util.test.ts
+++ b/test/project/util.test.ts
@@ -16,6 +16,7 @@
 
 import * as assert from "assert";
 import * as path from "path";
+
 import { Project } from "../../lib/project/project";
 import { globFiles } from "../../lib/project/util";
 

--- a/test/repository/filter.test.ts
+++ b/test/repository/filter.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "power-assert";
+
 import { Contextual } from "../../lib/handler";
 import {
 	matchesRefFilter,

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "power-assert";
+
 import { failure, success } from "../lib/status";
 
 describe("status", () => {

--- a/test/transact/transact.test.ts
+++ b/test/transact/transact.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "assert";
+
 import { Entity, flattenEntities } from "../../lib/transact/transact";
 
 describe("transact", () => {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from "assert";
+
 import { extractParameters, guid } from "../lib/util";
 
 describe("util", () => {


### PR DESCRIPTION
@ddgenome I've enabled a plugin to sort imports in our TS code. Let me know what you think about this change. If we like this, I would change our eslint-skill configuration to roll out that change and close this PR here.

I'm not too sure about the empty line between module and relative imports. But the rest of the sorting is a good addition IMHO so I'm willing to live with the empty line.