### PR TITLE
Adding upgradePolicy: unstable when configuring local skill

### DIFF
--- a/lib/script/skill_local_run.ts
+++ b/lib/script/skill_local_run.ts
@@ -87,7 +87,7 @@ export async function skillLocalRun(options: {
 	if (!configuredSkill?.activeSkill?.id) {
 		await gc.mutate(
 			`mutation ext_configureSkill($namespace: String!, $name: String!, $version: String) {
-  saveSkillConfiguration(namespace: $namespace, name: $name, version: $version, configuration: {displayName: "Docker Desktop Extension", name: "local_configured_skill", enabled: true}) {
+  saveSkillConfiguration(namespace: $namespace, name: $name, version: $version, configuration: {displayName: "Docker Desktop Extension", name: "local_configured_skill", enabled: true}, upgradePolicy: unstable) {
     configured {
       skills {
         id


### PR DESCRIPTION
Think this *may* be why the skill subscriptions were not being updated, as there is no policy to follow when re-registering a skill.

@cdupuis Not run this (don't know how), and might not have got it right, but our subscriptions were not being updated.