### PR TITLE
Adds the typing around retracting fields

### DIFF
--- a/lib/datalog/util.ts
+++ b/lib/datalog/util.ts
@@ -34,6 +34,7 @@ export type EntityType =
 	| Date[]
 	| { set: string[] }
 	| { add: string[] }
+	| { retract: true }
 	| {
 			args: Record<string, string | number>;
 			where: EntityRaw;


### PR DESCRIPTION
Very small PR just so that we can use the `{ retract: true }` within datalog transactions.