### PR TITLE
fix(staging): expose fns propagating correct per-env hub urls

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -239,6 +239,18 @@ export function isStaging(): boolean {
 	).includes("-stage");
 }
 
+export function dockerHubDomain(): string {
+	return process.env.DOCKERHUB_DOMAIN || "hub.docker.com";
+}
+
+export function dockerHubAuthDomain(): string {
+	return process.env.DOCKERHUB_AUTH_DOMAIN || "auth.docker.com";
+}
+
+export function dockerHubRegistryDomain(): string {
+	return process.env.DOCKERHUB_REGISTRY_DOMAIN || "registry-1.docker.io";
+}
+
 export function pluralize(
 	text: string,
 	count: number | any[],


### PR DESCRIPTION
Issue: https://github.com/atomisthq/automation-api/issues/1391

These env variables were added so that skills can correctly talk to the corresponding hub environment, and I wrapped them in functions here to provide sane defaults.