### PR TITLE
fix: restore npm release publishing

### DIFF
--- a/.github/workflows/release-npm-library.yml
+++ b/.github/workflows/release-npm-library.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  id-token: write
 jobs:
   publish-npm:
     name: Publish package
@@ -13,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run compile


### PR DESCRIPTION
## Summary
- enable `contents: write` and `id-token: write` on the release workflow so GitHub Actions can use npm trusted publishing
- move the publish job to Node 24 so the release runtime matches current npm OIDC support
- keep the existing `NODE_AUTH_TOKEN` path in place as fallback

## Validation
- `npm_config_cache=/tmp/npm-cache npm ci`
- `npm run gql:gen`
- `npm run compile:ts`
- `npm test`

## Notes
- the failing run died at `npm publish`, not during build or test
- this repo-side fix still needs npm-side trusted publisher setup for `@atomist/skill`, or a rotated valid `NPM_TOKEN`, to fully unblock publishing
- failing run: https://github.com/atomist-skills/skill/actions/runs/23498499053/job/68386429473#step:9:624