### PR TITLE
Use auth.docker.io as Docker Hub auth default

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -268,7 +268,7 @@ export function dockerHubDomain(): string {
 }
 
 export function dockerHubAuthDomain(): string {
-	return process.env.DOCKERHUB_AUTH_DOMAIN || "auth.docker.com";
+	return process.env.DOCKERHUB_AUTH_DOMAIN || "auth.docker.io";
 }
 
 export function dockerHubRegistryDomain(): string {


### PR DESCRIPTION
## Summary

Switch the Docker Hub auth fallback domain from `auth.docker.com` to `auth.docker.io` when `DOCKERHUB_AUTH_DOMAIN` is unset. Explicit environment overrides are unchanged.

## Testing

- `npm ci`
- `npm run gql:gen`
- `npm run compile:ts`
- `npx mocha --require espower-typescript/guess \"test/**/*.test.ts\" --exit`

Jira: DXT-859

Related PRs:
- atomisthq/fleet-infra#3006
- atomisthq/fleet-infra#3007
- atomisthq/api-cljs#103